### PR TITLE
Fix dataChanged slot name on table_page

### DIFF
--- a/table_page.cpp
+++ b/table_page.cpp
@@ -40,7 +40,7 @@ TablePage::TablePage(const QString& topicName,
     m_tableModel = std::make_unique<TopicTableModel>(topicTableView, m_topicName);
     topicTableView->setModel(m_tableModel.get());
     //topicTableView->setColumnWidth(TopicTableModel::STATUS_COLUMN, 21);
-    connect(m_tableModel.get(), SIGNAL(dataChanged()), this, SLOT(dataChanged()));
+    connect(m_tableModel.get(), SIGNAL(dataHasChanged()), this, SLOT(dataHasChanged()));
 
     // Create a topic monitor to receive the data samples
     m_topicMonitor = std::make_unique <TopicMonitor>(topicName);
@@ -515,7 +515,7 @@ void TablePage::on_topicTableView_pressed(const QModelIndex& index)
 
 
 //------------------------------------------------------------------------------
-void TablePage::dataChanged()
+void TablePage::dataHasChanged()
 {
     revertButton->setEnabled(true);
 }

--- a/table_page.h
+++ b/table_page.h
@@ -107,7 +107,7 @@ private slots:
     /**
      * @brief Enable appropriate buttons when data has changed in the model.
      */
-    void dataChanged();
+    void dataHasChanged();
 
     /**
      * @brief Update the history table with the latest data from DDS.


### PR DESCRIPTION
Problem: `dataChanged` has changed to `dataHasChanged` to avoid collision with other Qt signals / slots (as indicated by clazy)

Solution: Change to the new name.